### PR TITLE
fix: document turbot download body.on streaming bug and workaround (#63)

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,60 @@ Download the latest release from the [Releases page](https://github.com/turbot/g
 turbot --version
 ```
 
+## Troubleshooting
+
+### `turbot download` fails with `body.on is not a function`
+
+**Affected versions:** v1.32.x, v1.33.x  
+**Tracked in:** [#63](https://github.com/turbot/guardrails-cli/issues/63)
+
+`turbot download` exits with `Failed to download mod: re.body.on is not a function` and leaves an empty zip file. This is caused by the CLI calling `.on('data', ...)` on a native `fetch()` response body, which is a Web `ReadableStream` rather than a Node.js `stream.Readable` and does not expose `.on()`.
+
+**Workaround:** Capture the pre-signed S3 URL from the CLI's internal fetch calls and download it directly with `curl`:
+
+```bash
+# Step 1: Create a fetch interceptor that logs all URLs
+cat > /tmp/log-fetch-url.js << 'PATCH'
+const origFetch = globalThis.fetch;
+const fs = require('fs');
+globalThis.fetch = async function(...args) {
+  const url = typeof args[0] === 'string' ? args[0] : (args[0]?.url || '');
+  fs.appendFileSync('/tmp/turbot-s3-urls.log', url + '\n');
+  return origFetch(...args);
+};
+PATCH
+
+# Step 2: Run the download command (it will fail, but the URL gets logged)
+rm -f /tmp/turbot-s3-urls.log
+NODE_OPTIONS='--require /tmp/log-fetch-url.js' turbot download @turbot/aws-lambda --mod-version="5.19.1" 2>/dev/null || true
+
+# Step 3: Download the zip directly from the captured S3 URL
+S3_URL=$(grep 's3.amazonaws.com' /tmp/turbot-s3-urls.log | tail -1)
+curl -L -o turbot_aws-lambda.zip "$S3_URL"
+
+# Step 4: Upload to your workspace as usual
+turbot up --zip-file="turbot_aws-lambda.zip" --profile <your-profile>
+```
+
+**Fix (for CLI maintainers):** Replace the Node.js stream event listener pattern in the download implementation with `Readable.fromWeb()`:
+
+```js
+// Before (broken with native fetch — Web ReadableStream has no .on()):
+const re = await fetch(url);
+re.body.on('data', chunk => fileStream.write(chunk));
+re.body.on('end', () => fileStream.end());
+re.body.on('error', err => fileStream.destroy(err));
+
+// After (works with native fetch):
+import { Readable } from 'node:stream';
+import { pipeline } from 'node:stream/promises';
+
+const re = await fetch(url);
+await pipeline(Readable.fromWeb(re.body), fileStream);
+```
+
+`Readable.fromWeb()` is available since Node.js 17.5 / 16.15 — see [Node.js stream docs](https://nodejs.org/api/stream.html#streamreadablefromwebreadablestream-options).
+
 ## License & Terms
 
 The Turbot Guardrails CLI is closed source, proprietary software. It may be [downloaded


### PR DESCRIPTION
## Summary

- Documents the `turbot download` failure (`body.on is not a function`) affecting v1.32.x and v1.33.x in a new **Troubleshooting** section of the README
- Provides a `NODE_OPTIONS` workaround so users can download mods immediately without waiting for a CLI patch
- Includes the exact one-liner source fix (`Readable.fromWeb()`) for CLI maintainers to apply in the private source repo

## Root Cause (for CLI maintainers)

The download implementation calls `.on('data', ...)` on the response body returned by native `fetch()`. In Node.js 18+, `fetch()` returns a Web `ReadableStream` (which has no `.on()`), not the Node.js `stream.Readable` that `node-fetch` used to return. The fix is a one-liner:

```js
// Before:
const re = await fetch(url);
re.body.on('data', chunk => fileStream.write(chunk));  // ❌ TypeError

// After:
import { Readable } from 'node:stream';
import { pipeline } from 'node:stream/promises';
const re = await fetch(url);
await pipeline(Readable.fromWeb(re.body), fileStream);  // ✅
```

## Test plan

- [x] Verified bug reproduction on CLI v1.32.0-rc.1 and v1.33.0-rc.8 (Darwin/amd64)
- [x] Confirmed `NODE_OPTIONS` workaround successfully captures the S3 URL and `curl` downloads the zip
- [x] Confirmed downloaded zip (`@turbot/aws-lambda@5.19.1`, 39 MB) is valid and deploys successfully via `turbot up --zip-file`

Closes #63

🤖 Generated with [Claude Code](https://claude.com/claude-code)